### PR TITLE
feat: interviewstart 페이지 생성, 면접 전 사용자 정보 입력 기능 구현

### DIFF
--- a/app/(protected)/interviewstart.tsx
+++ b/app/(protected)/interviewstart.tsx
@@ -1,0 +1,183 @@
+import { useInterviewActions, useInterviewSettings } from '@/stores/interviewStore';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Card, Input, Text as RNEText } from '@rneui/themed';
+import { router } from 'expo-router';
+import React from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { z } from 'zod';
+
+const interviewSchema = z.object({
+  name: z.string().min(1, '이름을 입력해주세요.'),
+  company: z.string().min(1, '지원회사명을 입력해주세요.'),
+  job_title: z.string().min(1, '지원직무를 입력해주세요.'),
+  department: z.string().optional(),
+  skills: z.string().optional(),
+  certifications: z.string().optional(),
+  activities: z.string().optional(),
+});
+
+type InterviewFormData = z.infer<typeof interviewSchema>;
+
+export default function InterviewStartPage() {
+  const { t } = useTranslation();
+  const { setInterviewSettings } = useInterviewActions();
+  const settings = useInterviewSettings();
+
+  const [gender, setGender] = React.useState(settings.gender);
+  const [interviewerMode, setInterviewerMode] = React.useState(settings.interviewer_mode);
+  const [difficulty, setDifficulty] = React.useState(settings.difficulty);
+
+  const { control, handleSubmit, formState: { errors, isValid } } = useForm<InterviewFormData>({
+    resolver: zodResolver(interviewSchema),
+    defaultValues: {
+      name: settings.name,
+      company: settings.company,
+      job_title: settings.job_title,
+      department: settings.department,
+      skills: settings.skills,
+      certifications: settings.certifications,
+      activities: settings.activities,
+    },
+    mode: 'onChange',
+  });
+
+  const onSubmit = (data: InterviewFormData) => {
+    if (!gender || !interviewerMode || !difficulty) {
+      // 간단한 유효성 검사
+      alert('성별, 면접모드, 난이도를 선택해주세요.');
+      return;
+    }
+    setInterviewSettings({ 
+      ...data, 
+      gender, 
+      interviewer_mode: interviewerMode, 
+      difficulty 
+    });
+    router.push('/interview');
+  };
+
+  const renderSelectButtons = (value: any, setValue: any, options: any[]) => (
+    <View style={styles.selectContainer}>
+      {options.map(option => (
+        <Button
+          key={option.value}
+          title={option.label}
+          onPress={() => setValue(option.value)}
+          type={value === option.value ? 'solid' : 'outline'}
+          containerStyle={styles.selectButtonContainer}
+          buttonStyle={value === option.value ? styles.selectedButton : styles.unselectedButton}
+          titleStyle={value === option.value ? styles.selectedButtonText : styles.unselectedButtonText}
+        />
+      ))}
+    </View>
+  );
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
+      <Card containerStyle={styles.card}>
+        <RNEText h4 style={styles.title}>면접 설정</RNEText>
+
+        <Text style={styles.label}>이름 (필수)</Text>
+        <Controller control={control} name="name" render={({ field: { onChange, onBlur, value } }) => (
+          <Input placeholder="홍길동" value={value} onBlur={onBlur} onChangeText={onChange} errorMessage={errors.name?.message} />
+        )} />
+
+        <Text style={styles.label}>성별 (필수)</Text>
+        {renderSelectButtons(gender, setGender, [{ label: '남성', value: 'male' }, { label: '여성', value: 'female' }])}
+
+        <Text style={styles.label}>지원회사명 (필수)</Text>
+        <Controller control={control} name="company" render={({ field: { onChange, onBlur, value } }) => (
+          <Input placeholder="(주)아레스" value={value} onBlur={onBlur} onChangeText={onChange} errorMessage={errors.company?.message} />
+        )} />
+
+        <Text style={styles.label}>지원직무 (필수)</Text>
+        <Controller control={control} name="job_title" render={({ field: { onChange, onBlur, value } }) => (
+          <Input placeholder="프론트엔드 개발자" value={value} onBlur={onBlur} onChangeText={onChange} errorMessage={errors.job_title?.message} />
+        )} />
+
+        <Text style={styles.label}>면접 모드 (필수)</Text>
+        {renderSelectButtons(interviewerMode, setInterviewerMode, [{ label: '실무 면접', value: 'team_lead' }, { label: '임원 면접', value: 'executive' }])}
+
+        <Text style={styles.label}>난이도 (필수)</Text>
+        {renderSelectButtons(difficulty, setDifficulty, [{ label: '보통', value: 'normal' }, { label: '어려움', value: 'hard' }])}
+
+        <Text style={styles.label}>부서 (선택)</Text>
+        <Controller control={control} name="department" render={({ field: { onChange, onBlur, value } }) => (
+          <Input placeholder="개발팀" value={value} onBlur={onBlur} onChangeText={onChange} />
+        )} />
+
+        <Text style={styles.label}>특기 (선택)</Text>
+        <Controller control={control} name="skills" render={({ field: { onChange, onBlur, value } }) => (
+          <Input placeholder="React, TypeScript" value={value} onBlur={onBlur} onChangeText={onChange} />
+        )} />
+
+        <Text style={styles.label}>자격증 (선택)</Text>
+        <Controller control={control} name="certifications" render={({ field: { onChange, onBlur, value } }) => (
+          <Input placeholder="정보처리기사" value={value} onBlur={onBlur} onChangeText={onChange} />
+        )} />
+
+        <Text style={styles.label}>기타 활동 (선택)</Text>
+        <Controller control={control} name="activities" render={({ field: { onChange, onBlur, value } }) => (
+          <Input placeholder="오픈소스 프로젝트 참여" value={value} onBlur={onBlur} onChangeText={onChange} />
+        )} />
+
+        <Button
+          title="면접 시작하기"
+          onPress={handleSubmit(onSubmit)}
+          disabled={!isValid || !gender || !interviewerMode || !difficulty}
+          containerStyle={styles.buttonContainer}
+        />
+      </Card>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  contentContainer: {
+    padding: 16,
+    justifyContent: 'center',
+  },
+  card: {
+    borderRadius: 8,
+  },
+  title: {
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: '#333',
+    marginLeft: 10,
+  },
+  buttonContainer: {
+    marginTop: 16,
+  },
+  selectContainer: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    marginBottom: 16,
+    marginLeft: 10,
+  },
+  selectButtonContainer: {
+    marginRight: 10,
+  },
+  selectedButton: {
+    backgroundColor: '#000000',
+  },
+  unselectedButton: {
+    borderColor: '#000000',
+  },
+  selectedButtonText: {
+    color: '#FFFFFF',
+  },
+  unselectedButtonText: {
+    color: '#000000',
+  },
+});

--- a/components/ui/DesktopHeader.tsx
+++ b/components/ui/DesktopHeader.tsx
@@ -31,7 +31,7 @@ export default function DesktopHeader({ showNav = true }: DesktopHeaderProps) {
     },
     {
       title: t("components.header.navigation.interview"),
-      href: "/interview" as Href,
+      href: "/interviewstart" as Href,
     },
     {
       title: t("components.header.navigation.pricing"),

--- a/components/ui/MobileHeader.tsx
+++ b/components/ui/MobileHeader.tsx
@@ -46,7 +46,7 @@ export default function MobileHeader({
     },
     {
       title: t("components.header.navigation.interview"),
-      href: "/interview" as Href,
+      href: "/interviewstart" as Href,
     },
     {
       title: t("components.header.navigation.pricing"),

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -2,6 +2,7 @@ import { SignInSchema } from "@/schemas/auth";
 import { useRouter } from "expo-router";
 import { authService, type AuthResponse, type GoogleLoginPayload } from "../services/authService";
 import { useAuthStore } from "../stores/authStore";
+import { useInterviewStore } from "@/stores/interviewStore";
 
 export function useAuth() {
   const router = useRouter();
@@ -16,6 +17,7 @@ export function useAuth() {
   const signIn = async (data: SignInSchema) => {
     const authData = await authService.signIn(data);
     if (authData) {
+      useInterviewStore.getState().actions.clearInterviewSettings();
       setTokens(authData.access, authData.refresh);
       setUser(authData.user);
       setAuthenticated(true);
@@ -23,6 +25,7 @@ export function useAuth() {
   };
 
   const googleSignIn = async (data: GoogleLoginPayload) => {
+    useInterviewStore.getState().actions.clearInterviewSettings();
     const response = await authService.googleLogin(data);
     if ("status" in response && response.status === "registration_required") {
       setSocialSignUpData({
@@ -43,6 +46,7 @@ export function useAuth() {
 
   const logout = async () => {
     try {
+      useInterviewStore.getState().actions.clearInterviewSettings();
       await authService.logout();
     } catch (error) {
       console.error("Logout API call failed:", error);

--- a/stores/interviewStore.ts
+++ b/stores/interviewStore.ts
@@ -1,0 +1,92 @@
+import { Platform } from 'react-native';
+import { create } from 'zustand';
+import { storage as secureStorage } from '../utils/storage';
+
+const INTERVIEW_STORAGE_KEY = 'interview-storage';
+
+const interviewStorage = {
+  async setItem(value: string): Promise<void> {
+    if (Platform.OS === 'web') {
+      localStorage.setItem(INTERVIEW_STORAGE_KEY, value);
+    } else {
+      await secureStorage.setItem(INTERVIEW_STORAGE_KEY, value);
+    }
+  },
+  async getItem(): Promise<string | null> {
+    if (Platform.OS === 'web') {
+      return localStorage.getItem(INTERVIEW_STORAGE_KEY);
+    }
+    return await secureStorage.getItem(INTERVIEW_STORAGE_KEY);
+  },
+  async removeItem(): Promise<void> {
+    if (Platform.OS === 'web') {
+      localStorage.removeItem(INTERVIEW_STORAGE_KEY);
+    } else {
+      await secureStorage.deleteItem(INTERVIEW_STORAGE_KEY);
+    }
+  },
+};
+
+interface InterviewStateData {
+  name: string;
+  gender: 'male' | 'female' | null;
+  company: string;
+  job_title: string;
+  interviewer_mode: 'team_lead' | 'executive' | null;
+  difficulty: 'normal' | 'hard' | null;
+  department?: string;
+  skills?: string;
+  certifications?: string;
+  activities?: string;
+}
+
+interface InterviewState extends InterviewStateData {
+  actions: {
+    loadInterviewSettings: () => Promise<void>;
+    setInterviewSettings: (settings: InterviewStateData) => void;
+    clearInterviewSettings: () => void;
+  };
+}
+
+const initialState: InterviewStateData = {
+  name: '',
+  gender: null,
+  company: '',
+  job_title: '',
+  interviewer_mode: null,
+  difficulty: null,
+  department: '',
+  skills: '',
+  certifications: '',
+  activities: '',
+};
+
+export const useInterviewStore = create<InterviewState>((set, get) => ({
+  ...initialState,
+  actions: {
+    loadInterviewSettings: async () => {
+      try {
+        const storedSettings = await interviewStorage.getItem();
+        if (storedSettings) {
+          set(JSON.parse(storedSettings));
+        }
+      } catch (e) {
+        console.error("Failed to load interview settings.", e);
+      }
+    },
+    setInterviewSettings: (settings) => {
+      set(settings);
+      interviewStorage.setItem(JSON.stringify(settings));
+    },
+    clearInterviewSettings: () => {
+      set(initialState);
+      interviewStorage.removeItem();
+    },
+  },
+}));
+
+// 초기 로딩 시 데이터를 불러옵니다.
+useInterviewStore.getState().actions.loadInterviewSettings();
+
+export const useInterviewSettings = () => useInterviewStore((state) => state);
+export const useInterviewActions = () => useInterviewStore((state) => state.actions);


### PR DESCRIPTION
  ## 개요

  가상 면접 시작 전, 사용자의 정보를 입력받고 면접 환경을 설정할 수 있는 '면접 설정' 페이지를 새롭게 추가합니다.

  ## 배경

  기존에는 '가상 면접' 버튼 클릭 시 바로 면접 시뮬레이션으로 진입했습니다. 사용자에게 더 맞춤화된 면접 경험을 제공하기 위해, 사전에 지원 회사, 직무, 원하는 면접 모드 및 난이도 등의 정보를 입력받는 단계가 필요했습니다. 이 기능을 통해 수집된 데이터는 향후 사용자별 맞춤 질문 생성 등 면접 시뮬레이션 고도화에 활용될 수 있습니다.

  ## 변경 사항

   - '면접 설정' 페이지 추가 (`app/(protected)/interviewstart.tsx`)
   - 인터뷰 설정 상태 관리 로직 추가 (`stores/interviewStore.ts`)
   - 네비게이션 로직 수정 (`components/ui/DesktopHeader.tsx`, `MobileHeader.tsx`)

## 관련 이슈

#eunho_front1
